### PR TITLE
feat: add aerochain auth and registration API

### DIFF
--- a/app/api/aerochain/auth/me/route.ts
+++ b/app/api/aerochain/auth/me/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from "next/server";
+import { createAdminClient } from "@/lib/supabase-server";
+import { getCorsHeaders, handlePreflight } from "@/lib/cors";
+
+export async function OPTIONS(request: Request) {
+	return (
+		handlePreflight(request) ??
+		new Response(null, {
+			status: 204,
+			headers: getCorsHeaders(request.headers.get("origin")),
+		})
+	);
+}
+
+export async function GET(request: Request) {
+	const origin = request.headers.get("origin");
+	const cors = getCorsHeaders(origin);
+
+	const authHeader = request.headers.get("authorization");
+	const token = authHeader?.startsWith("Bearer ")
+		? authHeader.slice(7)
+		: null;
+
+	if (!token) {
+		return NextResponse.json(
+			{ error: "Missing authorization token" },
+			{ status: 401, headers: cors },
+		);
+	}
+
+	try {
+		const supabase = await createAdminClient();
+		const { data, error } = await supabase.auth.getUser(token);
+
+		if (error || !data.user) {
+			return NextResponse.json(
+				{ error: "Invalid or expired token" },
+				{ status: 401, headers: cors },
+			);
+		}
+
+		return NextResponse.json(
+			{
+				user: {
+					id: data.user.id,
+					email: data.user.email,
+				},
+			},
+			{ headers: cors },
+		);
+	} catch (err) {
+		console.error("Unexpected error in auth/me:", err);
+		return NextResponse.json(
+			{ error: "Internal server error" },
+			{ status: 500, headers: cors },
+		);
+	}
+}

--- a/app/api/aerochain/auth/send-otp/route.ts
+++ b/app/api/aerochain/auth/send-otp/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase-server";
+import { getCorsHeaders, handlePreflight } from "@/lib/cors";
+
+export async function OPTIONS(request: Request) {
+	return (
+		handlePreflight(request) ??
+		new Response(null, {
+			status: 204,
+			headers: getCorsHeaders(request.headers.get("origin")),
+		})
+	);
+}
+
+export async function POST(request: Request) {
+	const origin = request.headers.get("origin");
+	const cors = getCorsHeaders(origin);
+
+	try {
+		const { email } = await request.json();
+
+		if (!email) {
+			return NextResponse.json(
+				{ error: "Email is required" },
+				{ status: 400, headers: cors },
+			);
+		}
+
+		const supabase = await createClient();
+		const { error } = await supabase.auth.signInWithOtp({
+			email,
+			options: { shouldCreateUser: true },
+		});
+
+		if (error) {
+			console.error("OTP send error:", error);
+			return NextResponse.json(
+				{ error: "Failed to send OTP. Please try again." },
+				{ status: 500, headers: cors },
+			);
+		}
+
+		return NextResponse.json({ success: true }, { headers: cors });
+	} catch (err) {
+		console.error("Unexpected error in send-otp:", err);
+		return NextResponse.json(
+			{ error: "Internal server error" },
+			{ status: 500, headers: cors },
+		);
+	}
+}

--- a/app/api/aerochain/auth/verify-otp/route.ts
+++ b/app/api/aerochain/auth/verify-otp/route.ts
@@ -1,0 +1,61 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase-server";
+import { getCorsHeaders, handlePreflight } from "@/lib/cors";
+
+export async function OPTIONS(request: Request) {
+	return (
+		handlePreflight(request) ??
+		new Response(null, {
+			status: 204,
+			headers: getCorsHeaders(request.headers.get("origin")),
+		})
+	);
+}
+
+export async function POST(request: Request) {
+	const origin = request.headers.get("origin");
+	const cors = getCorsHeaders(origin);
+
+	try {
+		const { email, token } = await request.json();
+
+		if (!email || !token) {
+			return NextResponse.json(
+				{ error: "Email and token are required" },
+				{ status: 400, headers: cors },
+			);
+		}
+
+		const supabase = await createClient();
+		const { data, error } = await supabase.auth.verifyOtp({
+			email,
+			token,
+			type: "email",
+		});
+
+		if (error || !data.session || !data.user) {
+			return NextResponse.json(
+				{ error: error?.message ?? "Invalid or expired OTP" },
+				{ status: 401, headers: cors },
+			);
+		}
+
+		return NextResponse.json(
+			{
+				access_token: data.session.access_token,
+				refresh_token: data.session.refresh_token,
+				user: {
+					id: data.user.id,
+					email: data.user.email,
+				},
+			},
+			{ headers: cors },
+		);
+	} catch (err) {
+		console.error("Unexpected error in verify-otp:", err);
+		return NextResponse.json(
+			{ error: "Internal server error" },
+			{ status: 500, headers: cors },
+		);
+	}
+}

--- a/app/api/aerochain/register/route.ts
+++ b/app/api/aerochain/register/route.ts
@@ -1,0 +1,180 @@
+import { NextResponse } from "next/server";
+import { createAdminClient } from "@/lib/supabase-server";
+import { getCorsHeaders, handlePreflight } from "@/lib/cors";
+
+export async function OPTIONS(request: Request) {
+	return (
+		handlePreflight(request) ??
+		new Response(null, {
+			status: 204,
+			headers: getCorsHeaders(request.headers.get("origin")),
+		})
+	);
+}
+
+async function getAuthedUser(request: Request) {
+	const authHeader = request.headers.get("authorization");
+	const token = authHeader?.startsWith("Bearer ") ? authHeader.slice(7) : null;
+	if (!token) return null;
+
+	const supabase = await createAdminClient();
+	const { data, error } = await supabase.auth.getUser(token);
+	if (error || !data.user) return null;
+	return data.user;
+}
+
+// GET — fetch the current user's aerochain registration
+export async function GET(request: Request) {
+	const origin = request.headers.get("origin");
+	const cors = getCorsHeaders(origin);
+
+	const user = await getAuthedUser(request);
+	if (!user) {
+		return NextResponse.json(
+			{ error: "Unauthorized" },
+			{ status: 401, headers: cors },
+		);
+	}
+
+	try {
+		const supabase = await createAdminClient();
+		const { data, error } = await supabase
+			.from("aerochain_registrations")
+			.select("*")
+			.or(`user_id.eq.${user.id},lead_email.eq.${user.email}`)
+			.limit(1);
+
+		if (error) {
+			console.error("Error fetching aerochain registration:", error);
+			return NextResponse.json(
+				{ error: "Failed to fetch registration" },
+				{ status: 500, headers: cors },
+			);
+		}
+
+		if (!data || data.length === 0) {
+			return NextResponse.json({ registration: null }, { headers: cors });
+		}
+
+		const r = data[0];
+		return NextResponse.json(
+			{
+				registration: {
+					id: r.id,
+					teamName: r.team_name,
+					leadName: r.lead_name,
+					leadEmail: r.lead_email,
+					leadSemester: r.lead_semester,
+					leadRegNo: r.lead_reg_no,
+					leadPhone: r.lead_phone,
+					leadSection: r.lead_section,
+					leadDepartment: r.lead_department,
+					leadAltEmail: r.lead_alt_email,
+					members: r.members,
+					submittedAt: r.created_at,
+				},
+			},
+			{ headers: cors },
+		);
+	} catch (err) {
+		console.error("Unexpected error in GET /register:", err);
+		return NextResponse.json(
+			{ error: "Internal server error" },
+			{ status: 500, headers: cors },
+		);
+	}
+}
+
+// POST — create or update the user's aerochain registration
+export async function POST(request: Request) {
+	const origin = request.headers.get("origin");
+	const cors = getCorsHeaders(origin);
+
+	const user = await getAuthedUser(request);
+	if (!user) {
+		return NextResponse.json(
+			{ error: "Unauthorized" },
+			{ status: 401, headers: cors },
+		);
+	}
+
+	try {
+		const body = await request.json();
+		const { formData, existingId } = body;
+
+		if (!formData) {
+			return NextResponse.json(
+				{ error: "formData is required" },
+				{ status: 400, headers: cors },
+			);
+		}
+
+		const supabase = await createAdminClient();
+
+		const payload = {
+			user_id: user.id,
+			team_name: formData.teamName,
+			track: "AI",
+			lead_name: formData.leadName,
+			lead_email: formData.leadEmail,
+			lead_semester: formData.leadSemester,
+			lead_reg_no: formData.leadRegNo,
+			lead_phone: formData.leadPhone,
+			lead_section: formData.leadSection,
+			lead_department: formData.leadDepartment,
+			lead_alt_email: formData.leadAltEmail,
+			members: formData.members,
+			team_size: (formData.members?.length ?? 0) + 1,
+			updated_at: new Date().toISOString(),
+		};
+
+		let result;
+
+		if (existingId) {
+			result = await supabase
+				.from("aerochain_registrations")
+				.update(payload)
+				.eq("id", existingId)
+				.select();
+		} else {
+			// Check for existing record by email to avoid duplicates
+			const { data: existing } = await supabase
+				.from("aerochain_registrations")
+				.select("id")
+				.eq("lead_email", formData.leadEmail)
+				.limit(1);
+
+			if (existing && existing.length > 0) {
+				result = await supabase
+					.from("aerochain_registrations")
+					.update(payload)
+					.eq("id", existing[0].id)
+					.select();
+			} else {
+				result = await supabase
+					.from("aerochain_registrations")
+					.upsert(payload, { onConflict: "user_id" })
+					.select();
+			}
+		}
+
+		if (result.error) {
+			console.error("Error saving aerochain registration:", result.error);
+			return NextResponse.json(
+				{ error: "Failed to save registration" },
+				{ status: 500, headers: cors },
+			);
+		}
+
+		return NextResponse.json(
+			{ success: true, data: result.data?.[0] },
+			{ headers: cors },
+		);
+	} catch (err) {
+		console.error("Unexpected error in POST /register:", err);
+		return NextResponse.json(
+			{ error: "Internal server error" },
+			{ status: 500, headers: cors },
+		);
+	}
+}

--- a/lib/cors.ts
+++ b/lib/cors.ts
@@ -1,0 +1,31 @@
+const ALLOWED_ORIGINS = [
+	"https://aerochain.vercel.app",
+	"http://localhost:5173",
+];
+
+export function getCorsHeaders(
+	requestOrigin: string | null,
+): Record<string, string> {
+	const origin =
+		requestOrigin && ALLOWED_ORIGINS.includes(requestOrigin)
+			? requestOrigin
+			: ALLOWED_ORIGINS[0];
+
+	return {
+		"Access-Control-Allow-Origin": origin,
+		"Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+		"Access-Control-Allow-Headers": "Content-Type, Authorization",
+		"Access-Control-Max-Age": "86400",
+	};
+}
+
+export function handlePreflight(request: Request): Response | null {
+	if (request.method === "OPTIONS") {
+		const origin = request.headers.get("origin");
+		return new Response(null, {
+			status: 204,
+			headers: getCorsHeaders(origin),
+		});
+	}
+	return null;
+}

--- a/scripts/aerochain-registrations.sql
+++ b/scripts/aerochain-registrations.sql
@@ -1,0 +1,33 @@
+-- Migration: create aerochain_registrations table
+-- Run this in the Supabase SQL editor for the GFG-SRMIST project.
+
+CREATE TABLE IF NOT EXISTS aerochain_registrations (
+  id              UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id         UUID        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  team_name       TEXT        NOT NULL,
+  lead_name       TEXT        NOT NULL,
+  lead_email      TEXT        NOT NULL,
+  lead_semester   TEXT        NOT NULL,
+  lead_reg_no     TEXT        NOT NULL,
+  lead_phone      TEXT        NOT NULL,
+  lead_section    TEXT        NOT NULL,
+  lead_department TEXT        NOT NULL,
+  lead_alt_email  TEXT,
+  members         JSONB       NOT NULL DEFAULT '[]',
+  team_size       INTEGER     NOT NULL DEFAULT 1,
+  track           TEXT        NOT NULL DEFAULT 'AI',
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (user_id),
+  UNIQUE (lead_email)
+);
+
+-- Enable Row Level Security
+ALTER TABLE aerochain_registrations ENABLE ROW LEVEL SECURITY;
+
+-- API routes use the service role key, so no RLS policy needed for server-side writes.
+-- This policy allows authenticated users to read their own record if accessed directly.
+CREATE POLICY "Users can view own aerochain registration"
+  ON aerochain_registrations
+  FOR SELECT
+  USING (auth.uid() = user_id);


### PR DESCRIPTION
## Summary

Adds a set of API routes to the main site so the aerochain event site can delegate its entire auth and registration flow here, removing its direct Supabase dependency.

## New routes
| Route | Method | Purpose |
|---|---|---|
| `/api/aerochain/auth/send-otp` | POST | Send OTP email via Supabase |
| `/api/aerochain/auth/verify-otp` | POST | Verify OTP, return JWT tokens |
| `/api/aerochain/auth/me` | GET | Validate Bearer token, return user |
| `/api/aerochain/register` | GET / POST | Read / write aerochain registrations |

## Other changes
- `lib/cors.ts` — CORS helper allowing `https://aerochain.vercel.app` and `http://localhost:5173`
- `scripts/aerochain-registrations.sql` — migration script to create the `aerochain_registrations` table on the shared Supabase project

## Testing locally
Run `npm run dev` (port 3000) and point aerochain's `VITE_API_BASE_URL=http://localhost:3000`.